### PR TITLE
Improve minimum package error message

### DIFF
--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -139,12 +139,12 @@ class ConnectionHelper(object):
                 " ".join(lum), version="3.0.0", collection_name="paloaltonetworks.panos"
             )
 
-        # Verify pandevice minimum version.
+        # Verify pan-os-python (formerly pandevice) minimum version.
         if self.min_pandevice_version is not None:
             if pdv < self.min_pandevice_version:
                 module.fail_json(
                     msg=_MIN_VERSION_ERROR.format(
-                        "panos", panos.__version__, _vstr(self.min_pandevice_version)
+                        "pan-os-python", panos.__version__, _vstr(self.min_pandevice_version)
                     )
                 )
 


### PR DESCRIPTION
Current error message states "panos version < minimum" which infers PAN-OS version on firewall/Panorama. What is really meant is that the pan-os-python package is not at the minimum version.